### PR TITLE
Feature/apt-buildpack

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,23 @@
+# Add the location of the postgresql client tools installed by apt to `PATH`.
+# If you don't add the direct path to the binaries, `pg_wrapper` will get involved and **not work**.
+# This is because `pg_wrapper` is installed in `/home/vcap/deps/0/apt/usr/lib/postgresql/13/bin` by apt-buildpack, but Ubuntu expects them to be in `/usr/lib/postgresql/15/bin`.
+export PATH="${HOME}/deps/0/apt/usr/lib/postgresql/15/bin:${PATH}"
+
+# Create a .pgpass file with the credentials from the VCAP_SERVICES environment variable.
+if [ "$(jq -r 'has("aws-rds")' <<< "$VCAP_SERVICES")" == "true" ]; then
+    rm -f "${HOME}/.pgpass"
+
+    for item in $(jq -r '.["aws-rds"][] | @base64' <<< "$VCAP_SERVICES"); do
+        _get_credential() {
+            echo "$item" | base64 --decode | jq -r ".credentials.${1}"
+        }
+
+        host=$(_get_credential "HOST")
+        port=$(_get_credential "PORT")
+        database=$(_get_credential "DB_NAME")
+        username=$(_get_credential "USERNAME")
+        password=$(_get_credential "PASSWORD")
+
+        echo "${host}:${port}:${database}:${username}:${password}" >> "${HOME}/.pgpass"
+    done
+fi

--- a/README.md
+++ b/README.md
@@ -9,11 +9,7 @@
 
 ## Description
 
-SSH tunnel application for cloud.gov database connections. Dummy application bound to database services that provide a dedicated connection to the EASEY Database. The application leverages the [apt-buildpack](https://github.com/cloudfoundry/apt-buildpack) to incorporate PostgreSQL client tools within the app’s
-container. **Note that the apt-buildpack is considered experimental and is not supported by Cloud.gov. Using this in a production setting would require you to address the security controls.** This setup enables the execution of [Cloud Foundry Tasks](https://
-docs.cloudfoundry.org/devguide/using-tasks.html), allowing for the implementation of various PostgreSQL commands such as `pg_dump`, `pg_restore`, and
-`psql`. Importantly, each `aws-rds` service instance bound to the application manages its credentials automatically, eliminating the need to manually
-enter passwords when executing commands.
+SSH tunnel application for cloud.gov database connections. Dummy application bound to database services that provide a dedicated connection to the EASEY Database. The application leverages the [apt-buildpack](https://github.com/cloudfoundry/apt-buildpack) to incorporate PostgreSQL client tools within the app’s container. **Note that the apt-buildpack is considered experimental and is not supported by Cloud.gov. Using this in a production setting would require you to address the security controls.** This setup enables the execution of [Cloud Foundry Tasks](https://docs.cloudfoundry.org/devguide/using-tasks.html), allowing for the implementation of various PostgreSQL commands such as `pg_dump`, `pg_restore`, and `psql`. Importantly, each `aws-rds` service instance bound to the application manages its credentials automatically, eliminating the need to manually enter passwords when executing commands.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -8,29 +8,74 @@
 ![Stars](https://img.shields.io/github/stars/US-EPA-CAMD/ssh-tunnel-app)
 
 ## Description
-SSH tunnel application for cloud.gov database connections. Dummy application bound to database services that provide a dedicated connection to the EASEY Database.
+
+SSH tunnel application for cloud.gov database connections. Dummy application bound to database services that provide a dedicated connection to the EASEY Database. The application leverages the [apt-buildpack](https://github.com/cloudfoundry/apt-buildpack) to incorporate PostgreSQL client tools within the app’s
+container. **Note that the apt-buildpack is considered experimental and is not supported by Cloud.gov. Using this in a production setting would require you to address the security controls.** This setup enables the execution of [Cloud Foundry Tasks](https://
+docs.cloudfoundry.org/devguide/using-tasks.html), allowing for the implementation of various PostgreSQL commands such as `pg_dump`, `pg_restore`, and
+`psql`. Importantly, each `aws-rds` service instance bound to the application manages its credentials automatically, eliminating the need to manually
+enter passwords when executing commands.
 
 ## Getting Started
+
 Follow these [instructions](https://github.com/US-EPA-CAMD/devops/blob/master/GETTING-STARTED.md) to get the project up and running correctly.
 
 ## Installing
+
 1. Open a terminal and navigate to the directory where you wish to store the repository.
 2. Clone the repository using one of the following git cli commands or using your favorit Git management software<br>
-    **Using SSH**
-    ```
-    $ git clone git@github.com:US-EPA-CAMD/ssh-tunnel-app.git
-    ```
-    **Using HTTPS**
-    ```
-    $ git clone https://github.com/US-EPA-CAMD/ssh-tunnel-app.git
-    ```
+   **Using SSH**
+   ```
+   $ git clone git@github.com:US-EPA-CAMD/ssh-tunnel-app.git
+   ```
+   **Using HTTPS**
+   ```
+   $ git clone https://github.com/US-EPA-CAMD/ssh-tunnel-app.git
+   ```
 3. Navigate to the projects root directory
-    ```
-    $ cd ssh-tunnel-app
-    ```
+   ```
+   $ cd ssh-tunnel-app
+   ```
+
+## Usage as a Task Runner
+
+Modify the manifest.yml file or use the `cf` command line tool to bind the aws-rds postgres instance to the app. Push the app to cloud foundry.
+
+Run a task with the Cloud Foundry `run-task` command. The desired shell command to execute should be passed to the `--command` argument.
+
+```bash
+cf run-task --command 'psql -c "\pset tuples_only on" -c "SELECT version()" -c "\pset tuples_only off" -h host -p port -U user'
+```
+
+You can check the status of the task using the `cf tasks` command.
+
+```bash
+cf tasks ssh-tunnel
+
+Getting tasks for app ssh-tunnel in org my-org  / space my-space as user@name.com...
+
+id   name       state       start time                      command
+5    bfa9cef9   SUCCEEDED   Wed, 22 Mar 2023 21:07:56 UTC   psql -c "\pset tuples_only on" -c "select version()" -c "\pset tuples_only off" -h host -p port -U user
+```
+
+You can view the logs for the running task using the `cf logs` command.
+
+```bash
+cf logs ssh-tunnel --recent
+
+Retrieving logs for app ssh-tunnel in org my-org / space my-space as
+
+2020-03-22T21:07:56.00-0400 [APP/TASK/bfa9cef9/0] OUT 2020-03-23 01:07:56,000 INFO: PostgreSQL 15.7 (Ubuntu 14.13-0ubuntu0.22.04.1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit
+...
+```
+
+## PostgreSQL client tools
+
+The client tools are installed in the container using the apt-buildpack. You may need to modify the apt.yml file to install the correct version of the client tools for your target database. If you do this you will need to modify the PATH set in .profile to point to the correct location of the client tools. Without this change, pg_wrapper will try to locate the client tools in the default location in Ubuntu and fail.
 
 ## License & Contributing
+
 This project is licensed under the MIT License. We encourage you to read this project’s [License](LICENSE), [Contributing Guidelines](CONTRIBUTING.md), and [Code of Conduct](CODE-OF-CONDUCT.md).
 
 ## Disclaimer
+
 The United States Environmental Protection Agency (EPA) GitHub project code is provided on an "as is" basis and the user assumes responsibility for its use. EPA has relinquished control of the information and no longer has responsibility to protect the integrity , confidentiality, or availability of the information. Any reference to specific commercial products, processes, or services by service mark, trademark, manufacturer, or otherwise, does not constitute or imply their endorsement, recommendation or favoring by EPA. The EPA seal and logo shall not be used in any manner to imply endorsement of any commercial product or activity by EPA or the United States Government.

--- a/apt.yml
+++ b/apt.yml
@@ -1,0 +1,9 @@
+---
+truncatesources: true
+cleancache: true
+keys:
+  - https://www.postgresql.org/media/keys/ACCC4CF8.asc
+repos:
+  - deb https://apt.postgresql.org/pub/repos/apt jammy-pgdg main
+packages:
+  - postgresql-client-15

--- a/manifest.yml
+++ b/manifest.yml
@@ -4,6 +4,7 @@ applications:
     disk_quota: 1024M
     instances: 1
     buildpacks:
+      - https://github.com/cloudfoundry/apt-buildpack
       - staticfile_buildpack
     no-route: true
     services:


### PR DESCRIPTION
## Related Issues:

- [#6482](https://github.com/US-EPA-CAMD/easey-ui/issues/6482)

## Main Changes:

- Added the `apt-buildpack` to the application's list of buildpacks, and configured the packages to be installed.
  - Using `jammy-pgdg` as the `apt` suite specifier is not ideal (I did confirm `ssh-tunnel` is currently on "jammy"), but `apt-buildpack` doesn't evaluate the value, so it has to be declared explicitly as it will appear in `sources.list`. We may want to look into generating this configuration dynamically in the future. This doesn't look like it's currently possible, and may require a PR directly to the `apt-buildpack` repository.
- Added a shell initialization script (`~/.profile`) that parses the RDS credentials from the environment and generates a `.pgpass` file from them.