### PR TITLE
Feature/apt buildpack

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,7 +1,7 @@
 # Add the location of the postgresql client tools installed by apt to `PATH`.
 # If you don't add the direct path to the binaries, `pg_wrapper` will get involved and **not work**.
 # This is because `pg_wrapper` is installed in `/home/vcap/deps/0/apt/usr/lib/postgresql/13/bin` by apt-buildpack, but Ubuntu expects them to be in `/usr/lib/postgresql/15/bin`.
-export PATH="${HOME}/deps/0/apt/usr/lib/postgresql/15/bin:${PATH}"
+export PATH="/home/vcap/deps/0/apt/usr/lib/postgresql/15/bin:${PATH}"
 
 # Create a .pgpass file with the credentials from the VCAP_SERVICES environment variable.
 if [ "$(jq -r 'has("aws-rds")' <<< "$VCAP_SERVICES")" == "true" ]; then

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Modify the manifest.yml file or use the `cf` command line tool to bind the aws-r
 Run a task with the Cloud Foundry `run-task` command. The desired shell command to execute should be passed to the `--command` argument.
 
 ```bash
-cf run-task --command 'psql -c "\pset tuples_only on" -c "SELECT version()" -c "\pset tuples_only off" -h host -p port -U user'
+cf run-task ssh-tunnel --command 'psql <database> -c "\pset tuples_only on" -c "SELECT version()" -c "\pset tuples_only off" -h <host> -p <port> -U <user>'
 ```
 
 You can check the status of the task using the `cf tasks` command.
@@ -50,7 +50,7 @@ cf tasks ssh-tunnel
 Getting tasks for app ssh-tunnel in org my-org  / space my-space as user@name.com...
 
 id   name       state       start time                      command
-5    bfa9cef9   SUCCEEDED   Wed, 22 Mar 2023 21:07:56 UTC   psql -c "\pset tuples_only on" -c "select version()" -c "\pset tuples_only off" -h host -p port -U user
+5    bfa9cef9   SUCCEEDED   Wed, 22 Mar 2023 21:07:56 UTC   psql <database> -c "\pset tuples_only on" -c "select version()" -c "\pset tuples_only off" -h <host> -p <port> -U <user>
 ```
 
 You can view the logs for the running task using the `cf logs` command.

--- a/apt.yml
+++ b/apt.yml
@@ -1,5 +1,4 @@
 ---
-truncatesources: true
 cleancache: true
 keys:
   - https://www.postgresql.org/media/keys/ACCC4CF8.asc


### PR DESCRIPTION
## Main Changes:

- Removed the `truncatesources` option from `apt.yml`, since this was causing `apt` to be unable to find a necessary dependency, `libipc-run-perl`. The apt-buildpack documentation notes that enabling the option "_truncates the sources.list file and puts just the entries specified in repos section. This maybe needed in environment where ubuntu public repos are blocked_". **If removing this option is a security issue, we may need to grab the necessary package directly**.
- Updated the `PATH` assignment in the profile script. The example in [pg-db-tasks](https://github.com/USEPA/cf-pg-db-tasks/blob/main/.profile) is correct, but I had wrongly assumed that the `HOME` variable would point to _/home/vcap_ (it points to _/home/vcap/app_ when running a task).